### PR TITLE
fix: indent in test for multiline dict

### DIFF
--- a/assertions/mixed.json
+++ b/assertions/mixed.json
@@ -172,5 +172,6 @@
 	{"name": "empty_list_again", "input": "list:: []\n", "error": false},
 	{"name": "list_with_special_values", "input": "values:: null, true, false, nan, inf, -inf", "error": false},
 	{"name": "list_with_inline_dicts", "input": "contacts::\n  - :: type: \"admin\", email: \"admin@example.com\", bool: true, empty: null\n  - :: type: \"support\", email: \"support@example.com\", bool: true, empty: null", "error": false},
-	{"name": "list_with_multiline_dicts", "input": "contacts::\n  - ::\n      str: \"admin\"\n      num: 1234\n  - ::\n      str: \"admin2\"\n      num: 45.67", "error": false}
+	{"name": "list_with_badly_indented_multiline_dicts", "input": "contacts::\n  - ::\n      str: \"admin\"\n      num: 1234\n  - ::\n      str: \"admin2\"\n      num: 45.67", "error": true},
+	{"name": "list_with_multiline_dicts", "input": "contacts::\n  - ::\n    str: \"admin\"\n    num: 1234\n  - ::\n    str: \"admin2\"\n    num: 45.67", "error": false}
 ]


### PR DESCRIPTION
parser should complain when multiline dict has bad indent like this:
```yaml
- ::
    foo: "bar"
    baz: "qux"
```

should instead be:
```yaml
- ::
  foo: "bar"
  baz: "qux"
```